### PR TITLE
Control delete request response before updating component state

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -56,11 +56,13 @@ const App = () => {
 
   // Delete Task
   const deleteTask = async (id) => {
-    await fetch(`http://localhost:5000/tasks/${id}`, {
+    const res = await fetch(`http://localhost:5000/tasks/${id}`, {
       method: 'DELETE',
     })
-
-    setTasks(tasks.filter((task) => task.id !== id))
+    //We should control the response status to decide if we will change the state or not.
+    res.status === 200
+      ? setTasks(tasks.filter((task) => task.id !== id))
+      : alert('Error Deleting This Task')
   }
 
   // Toggle Reminder


### PR DESCRIPTION
We should control the response after making delete request if it is not successful we don't want to change components state. 