### PR TITLE
Correcting the reminder class condition.

### DIFF
--- a/src/components/Task.js
+++ b/src/components/Task.js
@@ -3,7 +3,7 @@ import { FaTimes } from 'react-icons/fa'
 const Task = ({ task, onDelete, onToggle }) => {
   return (
     <div
-      className={`task ${!task.reminder && 'reminder'}`}
+      className={`task ${task.reminder && 'reminder'}`}
       onDoubleClick={() => onToggle(task.id)}
     >
       <h3>


### PR DESCRIPTION
Fix for #12 
The short hand condition for setting the reminder class in the Task component was setting the class in a wrong way.